### PR TITLE
fix: add (* keep_hierarchy *) attribute to cells

### DIFF
--- a/src/cells.v
+++ b/src/cells.v
@@ -6,6 +6,7 @@ It's only needed for Wokwi designs.
 
 `define default_netname none
 
+(* keep_hierarchy *)
 module buffer_cell (
     input wire in,
     output wire out
@@ -13,6 +14,7 @@ module buffer_cell (
     assign out = in;
 endmodule
 
+(* keep_hierarchy *)
 module and_cell (
     input wire a,
     input wire b,
@@ -22,6 +24,7 @@ module and_cell (
     assign out = a & b;
 endmodule
 
+(* keep_hierarchy *)
 module or_cell (
     input wire a,
     input wire b,
@@ -31,6 +34,7 @@ module or_cell (
     assign out = a | b;
 endmodule
 
+(* keep_hierarchy *)
 module xor_cell (
     input wire a,
     input wire b,
@@ -40,6 +44,7 @@ module xor_cell (
     assign out = a ^ b;
 endmodule
 
+(* keep_hierarchy *)
 module nand_cell (
     input wire a,
     input wire b,
@@ -49,6 +54,7 @@ module nand_cell (
     assign out = !(a&b);
 endmodule
 
+(* keep_hierarchy *)
 module not_cell (
     input wire in,
     output wire out
@@ -57,6 +63,7 @@ module not_cell (
     assign out = !in;
 endmodule
 
+(* keep_hierarchy *)
 module mux_cell (
     input wire a,
     input wire b,
@@ -67,6 +74,7 @@ module mux_cell (
     assign out = sel ? b : a;
 endmodule
 
+(* keep_hierarchy *)
 module dff_cell (
     input wire clk,
     input wire d,
@@ -80,6 +88,7 @@ module dff_cell (
 
 endmodule
 
+(* keep_hierarchy *)
 module dffsr_cell (
     input wire clk,
     input wire d,


### PR DESCRIPTION
So the inverter loops (your ring oscillator) won't get optimized away by yosys. 

After merging this, please submit a new version of the design through https://app.tinytapeout.com/